### PR TITLE
Added support for Windows playback.

### DIFF
--- a/helm-spotify.el
+++ b/helm-spotify.el
@@ -5,15 +5,15 @@
 ;; Maintainer: Kris Jenkins <krisajenkins@gmail.com>
 ;; Keywords: helm spotify
 ;; URL: https://github.com/krisajenkins/helm-spotify
-;; Created: 6th October 2013
-;; Version: 0.1.0
+;; Created: 14th October 2013
+;; Version: 0.1.1
 ;; Package-Requires: ((helm "0.0.0") (multi "2.0.0"))
 
 ;;; Commentary:
 ;;
 ;; A search & play interface for Spotify.
 ;;
-;; Currently supports OSX & Linux.
+;; Currently supports OSX, Linux & Windows.
 ;;
 ;; (Want support for another platform? There's a guide in the github README.)
 
@@ -46,6 +46,10 @@
   (href)
   (shell-command (format "dbus-send --session --type=method_call --dest=com.spotify.qt / org.freedesktop.MediaPlayer2.OpenUri \"string:%s\""
 			 href)))
+
+(defmulti-method spotify-play-href 'windows-nt
+  (href)
+  (shell-command (format "explorer \"%s\"" href)))
 
 (defmulti-method-fallback spotify-play-href
   (href)


### PR DESCRIPTION
Hi!

I saw your "Writing A Spotify Client in 16 Minutes" and decided to try your Spotify client. I noticed that it did not have support for MS Windows, so I added this. I've tested it on Windows 7 and it seems to work (but it only opens album hrefs in the Spotify app, it does not play them).

/Erik Sjöstrand
