### PR TITLE
Updating to use new spotify web api

### DIFF
--- a/helm-spotify.el
+++ b/helm-spotify.el
@@ -135,13 +135,18 @@
                                 (string= (car other-track) format-string))
                                 (cdr tracks))))))))
 
+(defun helm-spotify-pattern ()
+  "Adds a wildcard to the end of the pattern"
+  (concat helm-pattern "*"))
+
+
 (defun helm-spotify-search-track ()
   "Run the search by track."
-  (spotify-search-formatted helm-pattern 'spotify-format-track))
+  (spotify-search-formatted (helm-spotify-pattern) 'spotify-format-track))
 
 (defun helm-spotify-search-album ()
   "Run the search by album."
-  (spotify-search-formatted helm-pattern 'spotify-format-album))
+  (spotify-search-formatted (helm-spotify-pattern) 'spotify-format-album))
 
 (defun helm-spotify-actions-for-track (actions track)
   "Return a list of helm ACTIONS available for this TRACK."

--- a/helm-spotify.el
+++ b/helm-spotify.el
@@ -66,11 +66,12 @@
 
 (defun spotify-search (search-term)
   "Search spotify for SEARCH-TERM, returning the results as a Lisp structure."
-  (let ((a-url (format "http://ws.spotify.com/search/1/track.json?q=%s" search-term)))
-    (with-current-buffer
-	(url-retrieve-synchronously a-url)
+  (let ((a-url (format "https://ws.spotify.com/search/1/track.json?q=%s" search-term)))
+    (let ((inhibit-message t))
+      (with-current-buffer
+        (url-retrieve-synchronously a-url)
       (goto-char url-http-end-of-headers)
-      (json-read))))
+      (json-read)))))
 
 (defun spotify-format-track (track)
   "Given a TRACK, return a a formatted string suitable for display."


### PR DESCRIPTION
I had a problem when updating to https where the echo area would display Opening TLS connection.... which screwed up the area where you enter the search. I used 'inhibit-messages around the https call to solve it, but this only works in emacs 25. If other people see the Opening TLS connection then you probably should just close this PR for now.
