### PR TITLE
Updates to search API

### DIFF
--- a/helm-spotify.el
+++ b/helm-spotify.el
@@ -4,7 +4,6 @@
 ;; Author: Kris Jenkins <krisajenkins@gmail.com>
 ;; Maintainer: Kris Jenkins <krisajenkins@gmail.com>
 ;; Keywords: helm spotify
-;; Package-Version: 20131014.1421
 ;; URL: https://github.com/krisajenkins/helm-spotify
 ;; Created: 14th October 2013
 ;; Version: 0.1.1


### PR DESCRIPTION
Spotify deprecated the previous search API used here, I updated to use the new one, and fixed a couple of issues I had playing tracks/albums on linux.