### PR TITLE
Fixes the 'Display not ready' error and album playing

### DIFF
--- a/helm-spotify.el
+++ b/helm-spotify.el
@@ -60,17 +60,10 @@
   "Get the Spotify app to play the TRACK."
   (spotify-play-href (alist-get '(uri) track)))
 
-(defun spotify-get-track (album-href)
-  (let ((response (with-current-buffer
-                   (url-retrieve-synchronously album-href)
-                   (goto-char url-http-end-of-headers)
-                   (json-read))))
-    (aref (alist-get '(tracks items) response) 0)))
-
 (defun spotify-play-album (track)
   "Get the Spotify app to play the album for this TRACK."
-  (let ((first-track (spotify-get-track (alist-get '(album href) track))))
-    (spotify-play-href (alist-get '(uri) first-track))))
+  (let ((album-uri (alist-get '(album uri) track)))
+    (spotify-play-href album-uri)))
 
 
 (defun spotify-search (search-term)
@@ -104,12 +97,6 @@
 (defun helm-spotify-search ()
   (spotify-search-formatted helm-pattern))
 
-(defun helm-spotify-actions-for-track (actions track)
-  "Return a list of helm ACTIONS available for this TRACK."
-  `((,(format "Play Track - %s" (alist-get '(name) track))       . spotify-play-track)
-    (,(format "Play Album - %s" (alist-get '(album name) track)) . spotify-play-album)
-    ("Show Track Metadata" . pp)))
-
 ;;;###autoload
 (defvar helm-source-spotify-track-search
   '((name . "Spotify")
@@ -117,15 +104,17 @@
     (delayed)
     (multiline)
     (requires-pattern . 2)
-    (candidates-process . helm-spotify-search)
-    (action-transformer . helm-spotify-actions-for-track)))
+    (candidates . helm-spotify-search)
+    (action . (("Play Track" . spotify-play-track)
+               ("Play Album" . spotify-play-album)
+               ("Play Track" . spotify-play-track)))))
 
 ;;;###autoload
 (defun helm-spotify ()
   "Bring up a Spotify search interface in helm."
   (interactive)
   (helm :sources '(helm-source-spotify-track-search)
-	:buffer "*helm-spotify*"))
+        :buffer "*helm-spotify*"))
 
 (provide 'helm-spotify)
 ;;; helm-spotify.el ends here


### PR DESCRIPTION
Right now, if I do a search and press `RET` on a track it says `[Display not
ready]` on the minibufer and it does nothing (I think it has to do with not
having any `action` defined in helm, just `action-transformer`).
With this fix, pressing `RET` or `TAB` on the track selected will trigger the
playing of the track.
One thing that will be lost in this PR is the name of the track in the options
(e.g: `Play track - <track name>`), but I think is better to have this fix that the
track name in that menu 👍 

Also, the `Play album` wasn't behaving properly. It just played the first song
of the track and then it stopped. The fix there has to do with the URI that is
passed to Spotify. And I think it isn't necesary to make another http call to
get the album information, its's just there in the first request, so i wipe out
that function (`spotify-get-track`) entirely